### PR TITLE
Update formats in engine.py

### DIFF
--- a/thumbor_vips_engine/engine.py
+++ b/thumbor_vips_engine/engine.py
@@ -16,12 +16,12 @@ from thumbor.engines import BaseEngine
 from thumbor.point import FocalPoint
 
 FORMATS = {
-    ".tif": "PNG",  # serve tif as png
+    ".tif": ".PNG",  # serve tif as png
     ".jpg": ".JPEG",
     ".jpeg": ".JPEG",
-    ".gif": "GIF",
-    ".png": "PNG",
-    ".webp": "WEBP",
+    ".gif": ".GIF",
+    ".png": ".PNG",
+    ".webp": ".WEBP",
 }
 
 


### PR DESCRIPTION
libvips uses target with dots so change few existing formats to conform to that.

`flake` was failing for me but after commenting it out the result of running `make test`:

```
------------------------------------------------------------------------------
Ran 18 tests in 0.50s

---------- coverage: platform linux, python 3.10.1-final-0 -----------
Name                                               Stmts   Miss  Cover
----------------------------------------------------------------------
thumbor_vips_engine/__init__.py                        1      0   100%
thumbor_vips_engine/engine.py                         78     16    79%
thumbor_vips_engine/testing/__init__.py                1      0   100%
thumbor_vips_engine/testing/engine_test_suite.py     111      6    95%
----------------------------------------------------------------------
TOTAL                                                191     22    88%


--------------------------- snapshot report summary ----------------------------

14 snapshots passed.

OK
************* Module /home/ec2-user/thumbor-vips-engine/pylintrc
pylintrc:1:0: R0022: Useless option value for '--disable', 'bad-continuation' was removed from pylint, see https://github.com/pylint-dev/pylint/pull/3571. (useless-option-value)
pylintrc:1:0: R0022: Useless option value for '--disable', 'no-self-use' was moved to an optional extension, see https://pylint.readthedocs.io/en/latest/whatsnew/2/2.14/summary.html#removed-checkers. (useless-option-value)

------------------------------------
Your code has been rated at 10.00/10
```